### PR TITLE
patch windows compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,3 +11,9 @@ add_subdirectory(pybind11)
 
 pybind11_add_module(pycolmap main.cc)
 target_link_libraries(pycolmap PRIVATE ${COLMAP_LIBRARIES})
+if(MSVC)
+# these are added in COLMAP_LIBRARIES for UNIX systems but for some reasons they are omited for windows
+# it crashes with LNK2019 because of that
+# https://github.com/colmap/colmap/blob/9f3a75ae9c72188244f2403eb085e51ecf4397a8/cmake/CMakeConfig.cmake.in#L165
+target_link_libraries(pycolmap PRIVATE ${Boost_FILESYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_SYSTEM_LIBRARY})
+endif()

--- a/README.md
+++ b/README.md
@@ -9,9 +9,29 @@ Clone the repository and its submodules by running:
 git clone --recursive git@github.com:mihaidusmanu/pycolmap.git
 ```
 
+## Unix
 COLMAP should be installed as a library before proceeding. Please refer to the official website for installation instructions. PyCOLMAP can be installed using `pip`: 
 ```
 pip install ./
+```
+
+## Windows
+To install pycolmap on Windows, we recommend to install colmap with [vcpkg](https://github.com/microsoft/vcpkg).
+From your vcpkg directory, run
+```
+.\vcpkg.exe install colmap --triplet=x64-windows
+```
+
+Then set the `CMAKE_TOOLCHAIN_FILE` environment variable to your `vcpkg\scripts\buildsystems\vcpkg.cmake` path.
+
+example (powershell)
+```
+$env:CMAKE_TOOLCHAIN_FILE='C:\Workspace\vcpkg\scripts\buildsystems\vcpkg.cmake'
+```
+
+Finally go to the pycolmap folder and run
+```
+py -m pip install ./
 ```
 
 # Usage

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,14 @@ class CMakeBuild(build_ext):
         build_args = ['--config', cfg]
 
         if platform.system() == "Windows":
+            if os.environ.get('CMAKE_TOOLCHAIN_FILE') is not None:
+                cmake_toolchain_file = os.environ.get('CMAKE_TOOLCHAIN_FILE')
+                # print(f'-DCMAKE_TOOLCHAIN_FILE={cmake_toolchain_file}')
+                cmake_args += [f'-DCMAKE_TOOLCHAIN_FILE={cmake_toolchain_file}']
             cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
             if sys.maxsize > 2**32:
+                if os.environ.get('CMAKE_TOOLCHAIN_FILE') is not None:
+                    cmake_args += ['-DVCPKG_TARGET_TRIPLET=x64-windows']
                 cmake_args += ['-A', 'x64']
             build_args += ['--', '/m']
         else:


### PR DESCRIPTION
Follow up of https://github.com/mihaidusmanu/pycolmap/pull/10

I took a better look at the cmake issue I was having. I traced it back to https://github.com/colmap/colmap/blob/9f3a75ae9c72188244f2403eb085e51ecf4397a8/cmake/CMakeConfig.cmake.in#L165 and linked the 3 boost libraries that are inside COLMAP_LIBRARIES on linux but not on windows.

In setup.py, I added a few lines for people who wants to use vcpkg. When the CMAKE_TOOLCHAIN_FILE environment variable is set, it sets the cmake command to use it.

I added the instructions in the readme file.