### PR TITLE
Version bump for pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='pycolmap',
-    version='0.0.1',
+    version='0.0.2',
     author='Mihai Dusmanu',
     author_email='mihai.dusmanu@inf.ethz.ch',
     description='COLMAP bindings',


### PR DESCRIPTION
Latest changes to `pycolmap` will be distributed on pypi as version 0.0.2, to keep them separate from 0.0.1.