### PR TITLE
Added Pybind Wrapper for COLMAP's Homography Decomposition Function

### DIFF
--- a/homography_decomposition.cc
+++ b/homography_decomposition.cc
@@ -23,7 +23,6 @@ py::dict homography_decomposition_estimation (
     // Check that both vectors have the same size.
     assert(points1.size() == points2.size());
 
-    // Pointers to R, t, n
     Eigen::Matrix3d R;
     Eigen::Vector3d t;
     Eigen::Vector3d n;
@@ -38,7 +37,7 @@ py::dict homography_decomposition_estimation (
     success_dict["R"] = R;
     success_dict["t"] = t;
     success_dict["n"] = n;
-    success_dict["best_points3D"] = points3D;
+    success_dict["points3D"] = points3D;
     
     return success_dict;
 }

--- a/homography_decomposition.cc
+++ b/homography_decomposition.cc
@@ -11,6 +11,17 @@ using namespace colmap;
 
 namespace py = pybind11;
 
+/**
+ * Recover the most probable pose from the inputted homography matrix.
+ * 
+ * @param H 3x3 homography matrix.
+ * @param K1 3x3 intrinsics matrix for first camera.
+ * @param K2 3x3 intrinsics matrix for second camera.
+ * @param points1 First set of corresponding points: normalized beforehand.
+ * @param points2 Second set of corresponding points: normalized beforehand.
+ * @return The most probable rotation matrix (3x3), translation vector (3x1), normal vector (3x1),
+ *         and triangulated 3D points.
+ */
 py::dict homography_decomposition_estimation (
     const Eigen::Matrix3d H,
     const Eigen::Matrix3d K1,

--- a/homography_decomposition.cc
+++ b/homography_decomposition.cc
@@ -38,6 +38,7 @@ py::dict homography_decomposition_estimation (
     success_dict["R"] = R;
     success_dict["t"] = t;
     success_dict["n"] = n;
+    success_dict["best_points3D"] = points3D;
     
     return success_dict;
 }

--- a/homography_decomposition.cc
+++ b/homography_decomposition.cc
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <fstream>
+
+#include "colmap/base/homography_matrix.h"
+
+using namespace colmap;
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/eigen.h>
+
+namespace py = pybind11;
+
+py::dict homography_decomposition_estimation (
+    const Eigen::Matrix3d H,
+    const Eigen::Matrix3d K1,
+    const Eigen::Matrix3d K2,
+    const std::vector<Eigen::Vector2d> points1,
+    const std::vector<Eigen::Vector2d> points2
+) {
+    SetPRNGSeed(0);
+
+    // Check that both vectors have the same size.
+    assert(points1.size() == points2.size());
+
+    // Pointers to R, t, n
+    Eigen::Matrix3d R;
+    Eigen::Vector3d t;
+    Eigen::Vector3d n;
+    std::vector<Eigen::Vector3d> points3D;
+
+    // Homography Decomposition Estimation
+    PoseFromHomographyMatrix(H, K1, K2, points1, points2, &R, &t, &n, &points3D)
+
+    // Success output dictionary.
+    py::dict success_dict;
+    success_dict["success"] = true;
+    success_dict["R"] = R;
+    success_dict["t"] = t;
+    success_dict["n"] = n;
+    
+    return success_dict;
+}

--- a/homography_decomposition.cc
+++ b/homography_decomposition.cc
@@ -30,7 +30,7 @@ py::dict homography_decomposition_estimation (
     std::vector<Eigen::Vector3d> points3D;
 
     // Homography Decomposition Estimation
-    PoseFromHomographyMatrix(H, K1, K2, points1, points2, &R, &t, &n, &points3D)
+    PoseFromHomographyMatrix(H, K1, K2, points1, points2, &R, &t, &n, &points3D);
 
     // Success output dictionary.
     py::dict success_dict;

--- a/main.cc
+++ b/main.cc
@@ -6,6 +6,7 @@ namespace py = pybind11;
 #include "generalized_absolute_pose.cc"
 #include "essential_matrix.cc"
 #include "fundamental_matrix.cc"
+#include "homography_decomposition.cc"
 #include "transformations.cc"
 #include "sift.cc"
 #include "pose_refinement.cc"

--- a/main.cc
+++ b/main.cc
@@ -56,6 +56,15 @@ PYBIND11_MODULE(pycolmap, m) {
           py::arg("confidence") = 0.9999,
           "LORANSAC + 7-point algorithm.");
 
+    // Homography Decomposition.
+    m.def("homography_decomposition", &homography_decomposition_estimation,
+          py::arg("H"), 
+          py::arg("K1"),
+          py::arg("K2"),
+          py::arg("points1"),
+          py::arg("points2"),
+          "Analytical Homography Decomposition.");
+
     // Image-to-world and world-to-image.
     m.def("image_to_world", &image_to_world, "Image to world transformation.");
     m.def("world_to_image", &world_to_image, "World to image transformation.");


### PR DESCRIPTION
Added a pybind wrapper over COLMAP's homography decomposition function: `PoseFromHomographyMatrix()` ([source code here](https://github.com/colmap/colmap/blob/dev/src/base/homography_matrix.h)). Named the python module: `homography_decomposition()`.

@johnwlambert and I are experimenting with it in our [gtsfm ](https://github.com/borglab/gtsfm) project to accurately decompose relative rotation and unit translations from a pair we suspect to be a homography.