### PR TITLE
[CI] Build wheels and publish to pypi

### DIFF
--- a/.github/workflows/build-new.yml
+++ b/.github/workflows/build-new.yml
@@ -1,0 +1,75 @@
+name: Pybind11 CI
+
+on:
+  push:
+    branches:
+      - master
+      - wheels
+  pull_request:
+    types: [ assigned, opened, synchronize, reopened ]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  linux-build:
+    name: Wrapper Linux Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pyversion: ["cp37-cp37m","cp38-cp38"] # "cp36-cp36m",  "cp39-cp39"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Build the Linux wheels
+      run: |
+        # must be run in docker, cannot be run as freestanding script for toolchain issues
+        # run on old CentOS. but it's CentOS, so it's yum(RPM) not apt. very old glibc. glibc API is back-compatible but not forward. See https://github.com/pypa/manylinux
+        # see https://github.com/varunagrawal/docker-images/blob/master/gtsam-manylinux/Dockerfile for an example
+        # container, but it does not have some necesssary boost packages --> varunagrawal/gtsam-manylinux:latest
+        sudo docker run --rm -e PLAT=manylinux2014_x86_64 -e PYTHON_VERSION=${{ matrix.pyversion }} -v `pwd`:/io quay.io/pypa/manylinux2014_x86_64 /io/package/build-wheels-linux.sh ${{ matrix.pyversion }}
+        # cleanup for custom runner
+        sudo chown -R $(whoami):$(whoami) .
+    - name: Archive wheels
+      uses: actions/upload-artifact@v2
+      with:
+        # we strip the version number from the artifact name
+        name: pycolmap-${{ matrix.pyversion }}-manylinux2014_x86_64
+        path: wheelhouse/pycolmap-*-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
+    - name: Publish package
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        packages_dir: wheelhouse/
+
+  mac-build:
+    name: Wrapper macOS Build
+    runs-on: macos-11
+    strategy:
+      matrix:
+        pyversion: ["python@3.8", "python@3.9"] # "python@3.7" not supported in Github Actions
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Build the macOS wheels
+      run: |
+        ./package/build-wheels-macos.sh ${{ matrix.pyversion }}
+    - name: Archive wheels
+      uses: actions/upload-artifact@v2
+      with:
+        # we strip the version number from the artifact name
+        name: pycolmap-${{ matrix.pyversion }}-macosx_11_0_x86_64
+        path: ./wheelhouse/pycolmap-*-macosx_11_0_x86_64.whl
+    - name: Publish package
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        packages_dir: wheelhouse/

--- a/.github/workflows/build-new.yml
+++ b/.github/workflows/build-new.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - wheels
   pull_request:
     types: [ assigned, opened, synchronize, reopened ]
   release:
@@ -39,6 +38,8 @@ jobs:
         name: pycolmap-${{ matrix.pyversion }}-manylinux2014_x86_64
         path: wheelhouse/pycolmap-*-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
     - name: Publish package
+      # We publish the wheel to pypi when a new tag is pushed,
+      # either by creating a new GitHub release or explictly with `git tag`
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -48,9 +49,10 @@ jobs:
 
   mac-build:
     name: Wrapper macOS Build
-    runs-on: macos-11
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [macos-11, macos-10.15]
         pyversion: ["python@3.8", "python@3.9"] # "python@3.7" not supported in Github Actions
     steps:
     - name: Checkout
@@ -63,9 +65,8 @@ jobs:
     - name: Archive wheels
       uses: actions/upload-artifact@v2
       with:
-        # we strip the version number from the artifact name
-        name: pycolmap-${{ matrix.pyversion }}-macosx_11_0_x86_64
-        path: ./wheelhouse/pycolmap-*-macosx_11_0_x86_64.whl
+        name: pycolmap-${{ matrix.pyversion }}-${{ matrix.os }}
+        path: ./wheelhouse/pycolmap-*.whl
     - name: Publish package
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vscode
+*.so
+*.egg-info/
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,15 @@
 cmake_minimum_required(VERSION 3.6)
 project(PyCOLMAP)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-
 find_package(COLMAP REQUIRED)
 include_directories(${COLMAP_INCLUDE_DIRS})
 link_directories(${COLMAP_LINK_DIRS})
+
+if (${CERES_VERSION} VERSION_LESS "2.0.0")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+endif()
 
 add_subdirectory(pybind11)
 

--- a/homography_estimation.cc
+++ b/homography_estimation.cc
@@ -1,0 +1,88 @@
+#include <iostream>
+#include <fstream>
+
+#include "colmap/estimators/homography_matrix.h"
+#include "colmap/optim/loransac.h"
+
+using namespace colmap;
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/eigen.h>
+
+namespace py = pybind11;
+
+/**
+ * Recover the most probable pose from the inputted homography matrix.
+ * 
+ * @param points2D1 First set of corresponding points.
+ * @param points2D2 Second set of corresponding points.
+ * @param max_error_px
+ * @param min_inlier_ratio
+ * @param min_num_trials
+ * @param max_num_trials
+ * @return The estimated homography matrix (3x3), ...
+ */
+py::dict homography_matrix_estimation(
+        const std::vector<Eigen::Vector2d> points2D1,
+        const std::vector<Eigen::Vector2d> points2D2,
+        const double max_error_px,
+        const double min_inlier_ratio,
+        const int min_num_trials,
+        const int max_num_trials,
+        const double confidence
+) {
+    SetPRNGSeed(0);
+
+    // Check that both vectors have the same size.
+    assert(points2D1.size() == points2D2.size());
+
+    // Failure output dictionary.
+    py::dict failure_dict;
+    failure_dict["success"] = false;
+
+    // Fundamental matrix estimation parameters.
+    RANSACOptions ransac_options;
+    ransac_options.max_error = max_error_px;
+    ransac_options.min_inlier_ratio = min_inlier_ratio;
+    ransac_options.min_num_trials = min_num_trials;
+    ransac_options.max_num_trials = max_num_trials;
+    ransac_options.confidence = confidence;
+    
+    // Estimate planar or panoramic model.
+    LORANSAC<
+        HomographyMatrixEstimator,
+        HomographyMatrixEstimator
+    > H_ransac(ransac_options);
+
+    // Homography matrix estimation.
+    const auto report = H_ransac.Estimate(points2D1, points2D2);
+
+    if (!report.success) {
+        return failure_dict;
+    }
+
+    // Recover data from report.
+    const Eigen::Matrix3d H = report.model;
+    const size_t num_inliers = report.support.num_inliers;
+    const auto inlier_mask = report.inlier_mask;
+    
+    // Convert vector<char> to vector<int>.
+    std::vector<bool> inliers;
+    for (auto it : inlier_mask) {
+        if (it) {
+            inliers.push_back(true);
+        } else {
+            inliers.push_back(false);
+        }
+    }
+
+    // Success output dictionary.
+    py::dict success_dict;
+    success_dict["success"] = true;
+    success_dict["H"] = H;
+    success_dict["num_inliers"] = num_inliers;
+    success_dict["inliers"] = inliers;
+    
+    return success_dict;
+}

--- a/main.cc
+++ b/main.cc
@@ -11,6 +11,7 @@ namespace py = pybind11;
 #include "transformations.cc"
 #include "sift.cc"
 #include "pose_refinement.cc"
+#include "two_view_geometry_estimation.cc"
 
 PYBIND11_MODULE(pycolmap, m) {
     m.doc() = "COLMAP plugin";
@@ -100,4 +101,17 @@ PYBIND11_MODULE(pycolmap, m) {
           py::arg("inlier_mask"),
           py::arg("camera_dict"),
           "Non-linear refinement.");
+    
+    // Generic two view geometry estimation.
+    m.def("two_view_geometry_estimation", &two_view_geometry_estimation,
+          py::arg("points2D1"),
+          py::arg("points2D2"),
+          py::arg("camera_dict1"),
+          py::arg("camera_dict2"),
+          py::arg("max_error_px") = 4.0,
+          py::arg("min_inlier_ratio") = 0.01,
+          py::arg("min_num_trials") = 1000,
+          py::arg("max_num_trials") = 100000,
+          py::arg("confidence") = 0.9999,
+          "Generic two-view geometry estimation");
 }

--- a/main.cc
+++ b/main.cc
@@ -6,6 +6,7 @@ namespace py = pybind11;
 #include "generalized_absolute_pose.cc"
 #include "essential_matrix.cc"
 #include "fundamental_matrix.cc"
+#include "homography_estimation.cc"
 #include "homography_decomposition.cc"
 #include "transformations.cc"
 #include "sift.cc"
@@ -62,6 +63,16 @@ PYBIND11_MODULE(pycolmap, m) {
           py::arg("confidence") = 0.9999,
           "LORANSAC + 7-point algorithm.");
 
+    // Homography matrix estimation.
+    m.def("homography_matrix_estimation", &homography_matrix_estimation,
+          py::arg("points2D1"), py::arg("points2D2"),
+          py::arg("max_error_px") = 4.0,
+          py::arg("min_inlier_ratio") = 0.01,
+          py::arg("min_num_trials") = 1000,
+          py::arg("max_num_trials") = 100000,
+          py::arg("confidence") = 0.9999,
+          "LORANSAC + 4-point DLT algorithm.");
+    
     // Homography Decomposition.
     m.def("homography_decomposition", &homography_decomposition_estimation,
           py::arg("H"), 

--- a/main.cc
+++ b/main.cc
@@ -13,6 +13,11 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(pycolmap, m) {
     m.doc() = "COLMAP plugin";
+#ifdef VERSION_INFO
+    m.attr("__version__") = py::str(VERSION_INFO);
+#else
+    m.attr("__version__") = py::str("dev");
+#endif
 
     // Absolute pose.
     m.def("absolute_pose_estimation", &absolute_pose_estimation,

--- a/package/build-wheels-linux.sh
+++ b/package/build-wheels-linux.sh
@@ -5,7 +5,6 @@
 # and http://ceres-solver.org/installation.html (Ceres)
 # However, the OS is centOS 7, instead of Ubuntu.
 
-
 uname -a
 echo "Current CentOS Version:"
 cat /etc/centos-release
@@ -35,20 +34,16 @@ PYTHON_EXECUTABLE=${PYBIN}/python
 PYTHON_INCLUDE_DIR=$(${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())")
 PYTHON_LIBRARY=$(${PYTHON_EXECUTABLE} -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
 
-
 CURRDIR=$(pwd)
-COLMAP_BRANCH="dev"
 
 echo "Num. processes to use for building: ${nproc}"
 
-
-# ----- Install boost (build it staticly) ---------------------------------------
-# colmap needs only program_options filesystem graph system unit_test_framework)
-
+# ------ Install boost (build it staticly) ------
 cd $CURRDIR
 yum install -y wget libicu libicu-devel centos-release-scl-rh devtoolset-7-gcc-c++
 
 # Download and install Boost-1.65.1
+# colmap needs only program_options filesystem graph system unit_test_framework
 mkdir -p boost && \
     cd boost && \
     wget -nv https://boostorg.jfrog.io/artifactory/main/release/1.65.1/source/boost_1_65_1.tar.gz && \
@@ -60,7 +55,8 @@ mkdir -p boost && \
 # Boost should now be visible under /usr/local
 ls -ltrh /usr/local
 
-# ----------- Install dependencies from the default Ubuntu repositories -----------------
+# ------ Install dependencies from the default Ubuntu repositories ------
+cd $CURRDIR
 yum install \
     git \
     cmake \
@@ -82,71 +78,49 @@ yum install \
 yum install libcgal-qt5-dev
 
 
-
-
-cd $CURRDIR
-
 # Note: `yum install gflags` will not work, since the version is too old (2.1)
 # Note: `yum install glog` will also not work, since the version is too old
 # Cloning and building https://github.com/google/glog.git will also not work, due to linker issues.
 yum -y install gflags-devel glog-devel
 
-
 cd $CURRDIR
-
-
-# wget https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
-# tar -xvzf eigen-3.4.0.tar.gz
-
 # Using Eigen 3.3, not Eigen 3.4
 wget https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.gz
 tar -xvzf eigen-3.3.9.tar.gz
-
-echo "CMAKE_PREFIX_PATH -> $CMAKE_PREFIX_PATH"
-# export CMAKE_PREFIX_PATH="/eigen-3.4.0/cmake/"
-export CMAKE_PREFIX_PATH="/eigen-3.3.9/cmake/"
-echo "CMAKE_PREFIX_PATH -> $CMAKE_PREFIX_PATH"
-
-ls -ltrh CMAKE_PREFIX_PATH/
+export EIGEN_DIR="$CURRDIR/eigen-3.3.9"
 
 # While Eigen is a header-only library, it still has to be built!
 # Creates Eigen3Config.cmake from Eigen3Config.cmake.in
-cd /eigen-3.3.9
+cd $EIGEN_DIR
 mkdir build
 cd build
 cmake ..
 
-ls -ltrh $CMAKE_PREFIX_PATH
+ls -ltrh "$EIGEN_DIR/cmake/"
 
+# ------ Install CERES solver ------
 cd $CURRDIR
-# ----------- Install CERES solver -------------------------------------------------------
 yum install libeigen3-dev # was not in COLMAP instructions
 yum install libatlas-base-dev libsuitesparse-dev
 yum install libgoogle-glog-dev libgflags-dev # was not in COLMAP instructions
+
 git clone https://ceres-solver.googlesource.com/ceres-solver
 cd ceres-solver
-#git checkout $(git describe --tags) # Checkout the latest release
-# the tip of master is currently bugged
-git checkout c2fab6502e5a341ff644c2bb2c5171ebd882b2d6
+git checkout $(git describe --tags) # Checkout the latest release
 mkdir build
 cd build
 cmake .. -DBUILD_TESTING=OFF \
          -DBUILD_EXAMPLES=OFF \
-         -DEigen3_DIR=$CMAKE_PREFIX_PATH
+         -DEigen3_DIR="$EIGEN_DIR/cmake/"
 make -j$(nproc)
 make install
 
-
-cd $CURRDIR
-
-echo ""
 echo "PYTHON_EXECUTABLE:${PYTHON_EXECUTABLE}"
 echo "PYTHON_INCLUDE_DIR:${PYTHON_INCLUDE_DIR}"
 echo "PYTHON_LIBRARY:${PYTHON_LIBRARY}"
-echo ""
 
-# ---------- Fix broken dependencies -----
-
+# ------ Fix broken dependencies ------
+cd $CURRDIR
 # try new boost install
 yum install libboost-all-dev
 yum install git
@@ -170,7 +144,7 @@ yum install libcgal-qt5-dev
 
 yum -y install freeimage
 
-### ------ Build FreeImage from source and install --------------------
+# ------ Build FreeImage from source and install ------
 cd $CURRDIR
 wget http://downloads.sourceforge.net/freeimage/FreeImage3180.zip
 unzip FreeImage3180.zip
@@ -181,19 +155,17 @@ make install
 # Install GLEW
 yum -y install glew-devel
 
-# ---------------- Clone COLMAP ----------------------------------------------------------
+# ------ Build COLMAP ------
 cd $CURRDIR
 git clone https://github.com/colmap/colmap.git
 cd colmap
 git checkout dev
-
-# ----------- Build COLMAP ------------------------------------------------------------
 mkdir build/
 cd build/
 cmake .. -DCMAKE_BUILD_TYPE=Release \
          -DBoost_USE_STATIC_LIBS=ON \
          -DBOOST_ROOT=/usr/local \
-         -DEIGEN3_INCLUDE_DIRS=/eigen-3.3.9
+         -DEIGEN3_INCLUDE_DIRS=$EIGEN_DIR
 
 if [ $ec -ne 0 ]; then
     echo "Error:"
@@ -201,29 +173,18 @@ if [ $ec -ne 0 ]; then
     exit $ec
 fi
 set -e -x
-
 make -j$(nproc) install
 
-mkdir -p /io/wheelhouse
-
-# ----------- Build pycolmap wheel -----------------------------------------------------
+# ------ Build pycolmap wheel ------
 cd /io/
-#cp package/setup_centos.py setup.py
 cat setup.py
 
 PLAT=manylinux2014_x86_64
-#"${PYBIN}/python" setup.py bdist_wheel --python-tag=$PYTHONVER --plat-name=$PLAT
-EIGEN3_INCLUDE_DIRS="/eigen-3.3.9" "${PYBIN}/python" setup.py bdist_wheel --plat-name=$PLAT #--python-tag=$PYTHONVER
+EIGEN3_INCLUDE_DIRS="$EIGEN_DIR" "${PYBIN}/python" setup.py bdist_wheel --plat-name=$PLAT
 
 # Bundle external shared libraries into the wheels
+mkdir -p /io/wheelhouse
 for whl in ./dist/*.whl; do
     auditwheel repair "$whl" -w /io/wheelhouse/ --no-update-tags
 done
-
 ls -ltrh /io/wheelhouse/
-# for whl in /io/wheelhouse/*.whl; do
-#     new_filename=$(echo $whl | sed "s#\.none-manylinux2014_x86_64\.#.#g")
-#     new_filename=$(echo $new_filename | sed "s#\.manylinux2014_x86_64\.#.#g") # For 37 and 38
-#     new_filename=$(echo $new_filename | sed "s#-none-#-#g")
-#     mv $whl $new_filename
-# done

--- a/package/build-wheels-linux.sh
+++ b/package/build-wheels-linux.sh
@@ -13,8 +13,6 @@ yum -y install wget
 
 ls -ltrh /io/
 
-yum -y install qt5-qtbase-devel
-
 # we cannot simply use `pip` or `python`, since points to old 2.7 version
 PYBIN="/opt/python/$PYTHON_VERSION/bin"
 PYVER_NUM=$($PYBIN/python -c "import sys;print(sys.version.split(\" \")[0])")
@@ -72,10 +70,7 @@ yum install \
     libgoogle-glog-dev \
     libgflags-dev \
     libglew-dev \
-    qtbase5-dev \
-    libqt5opengl5-dev \
     libcgal-dev
-yum install libcgal-qt5-dev
 
 
 # Note: `yum install gflags` will not work, since the version is too old (2.1)
@@ -137,10 +132,7 @@ yum install libsuitesparse-dev
 yum install libgoogle-glog-dev
 yum install libgflags-dev
 yum install libglew-dev
-yum install qtbase5-dev
-yum install libqt5opengl5-dev
 yum install libcgal-dev
-yum install libcgal-qt5-dev
 
 yum -y install freeimage
 
@@ -162,9 +154,10 @@ cd colmap
 git checkout dev
 mkdir build/
 cd build/
-cmake .. -DCMAKE_BUILD_TYPE=Release \
+CXXFLAGS="-fPIC" CFLAGS="-fPIC" cmake .. -DCMAKE_BUILD_TYPE=Release \
          -DBoost_USE_STATIC_LIBS=ON \
          -DBOOST_ROOT=/usr/local \
+         -DGUI_ENABLED=OFF \
          -DEIGEN3_INCLUDE_DIRS=$EIGEN_DIR
 
 if [ $ec -ne 0 ]; then

--- a/package/build-wheels-linux.sh
+++ b/package/build-wheels-linux.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+
+# Installation based off of https://colmap.github.io/install.html (COLMAP)
+# and https://github.com/mihaidusmanu/pycolmap#getting-started (pycolmap)
+# and http://ceres-solver.org/installation.html (Ceres)
+# However, the OS is centOS 7, instead of Ubuntu.
+
+
+uname -a
+echo "Current CentOS Version:"
+cat /etc/centos-release
+
+yum -y install wget
+
+ls -ltrh /io/
+
+yum -y install qt5-qtbase-devel
+
+# we cannot simply use `pip` or `python`, since points to old 2.7 version
+PYBIN="/opt/python/$PYTHON_VERSION/bin"
+PYVER_NUM=$($PYBIN/python -c "import sys;print(sys.version.split(\" \")[0])")
+PYTHONVER="$(basename $(dirname $PYBIN))"
+
+echo "Python bin path: $PYBIN"
+echo "Python version number: $PYVER_NUM"
+echo "Python version: $PYTHONVER"
+
+export PATH=$PYBIN:$PATH
+
+${PYBIN}/pip install auditwheel
+
+PYTHON_EXECUTABLE=${PYBIN}/python
+# We use distutils to get the include directory and the library path directly from the selected interpreter
+# We provide these variables to CMake to hint what Python development files we wish to use in the build.
+PYTHON_INCLUDE_DIR=$(${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())")
+PYTHON_LIBRARY=$(${PYTHON_EXECUTABLE} -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))")
+
+
+CURRDIR=$(pwd)
+COLMAP_BRANCH="dev"
+
+echo "Num. processes to use for building: ${nproc}"
+
+
+# ----- Install boost (build it staticly) ---------------------------------------
+# colmap needs only program_options filesystem graph system unit_test_framework)
+
+cd $CURRDIR
+yum install -y wget libicu libicu-devel centos-release-scl-rh devtoolset-7-gcc-c++
+
+# Download and install Boost-1.65.1
+mkdir -p boost && \
+    cd boost && \
+    wget -nv https://boostorg.jfrog.io/artifactory/main/release/1.65.1/source/boost_1_65_1.tar.gz && \
+    tar xzf boost_1_65_1.tar.gz && \
+    cd boost_1_65_1 && \
+    ./bootstrap.sh --with-libraries=serialization,filesystem,thread,system,atomic,date_time,timer,chrono,program_options,regex,graph,test && \
+    ./b2 -j$(nproc) cxxflags="-fPIC" runtime-link=static variant=release link=static install
+
+# Boost should now be visible under /usr/local
+ls -ltrh /usr/local
+
+# ----------- Install dependencies from the default Ubuntu repositories -----------------
+yum install \
+    git \
+    cmake \
+    build-essential \
+    libboost-program-options-dev \
+    libboost-filesystem-dev \
+    libboost-graph-dev \
+    libboost-system-dev \
+    libboost-test-dev \
+    libeigen3-dev \
+    libsuitesparse-dev \
+    libfreeimage-dev \
+    libgoogle-glog-dev \
+    libgflags-dev \
+    libglew-dev \
+    qtbase5-dev \
+    libqt5opengl5-dev \
+    libcgal-dev
+yum install libcgal-qt5-dev
+
+
+
+
+cd $CURRDIR
+
+# Note: `yum install gflags` will not work, since the version is too old (2.1)
+# Note: `yum install glog` will also not work, since the version is too old
+# Cloning and building https://github.com/google/glog.git will also not work, due to linker issues.
+yum -y install gflags-devel glog-devel
+
+
+cd $CURRDIR
+
+
+# wget https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
+# tar -xvzf eigen-3.4.0.tar.gz
+
+# Using Eigen 3.3, not Eigen 3.4
+wget https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.gz
+tar -xvzf eigen-3.3.9.tar.gz
+
+echo "CMAKE_PREFIX_PATH -> $CMAKE_PREFIX_PATH"
+# export CMAKE_PREFIX_PATH="/eigen-3.4.0/cmake/"
+export CMAKE_PREFIX_PATH="/eigen-3.3.9/cmake/"
+echo "CMAKE_PREFIX_PATH -> $CMAKE_PREFIX_PATH"
+
+ls -ltrh CMAKE_PREFIX_PATH/
+
+# While Eigen is a header-only library, it still has to be built!
+# Creates Eigen3Config.cmake from Eigen3Config.cmake.in
+cd /eigen-3.3.9
+mkdir build
+cd build
+cmake ..
+
+ls -ltrh $CMAKE_PREFIX_PATH
+
+cd $CURRDIR
+# ----------- Install CERES solver -------------------------------------------------------
+yum install libeigen3-dev # was not in COLMAP instructions
+yum install libatlas-base-dev libsuitesparse-dev
+yum install libgoogle-glog-dev libgflags-dev # was not in COLMAP instructions
+git clone https://ceres-solver.googlesource.com/ceres-solver
+cd ceres-solver
+#git checkout $(git describe --tags) # Checkout the latest release
+# the tip of master is currently bugged
+git checkout c2fab6502e5a341ff644c2bb2c5171ebd882b2d6
+mkdir build
+cd build
+cmake .. -DBUILD_TESTING=OFF \
+         -DBUILD_EXAMPLES=OFF \
+         -DEigen3_DIR=$CMAKE_PREFIX_PATH
+make -j$(nproc)
+make install
+
+
+cd $CURRDIR
+
+echo ""
+echo "PYTHON_EXECUTABLE:${PYTHON_EXECUTABLE}"
+echo "PYTHON_INCLUDE_DIR:${PYTHON_INCLUDE_DIR}"
+echo "PYTHON_LIBRARY:${PYTHON_LIBRARY}"
+echo ""
+
+# ---------- Fix broken dependencies -----
+
+# try new boost install
+yum install libboost-all-dev
+yum install git
+yum install cmake
+yum install build-essential
+yum install libboost-program-options-dev
+yum install libboost-filesystem-dev
+yum install libboost-graph-dev
+yum install libboost-system-dev
+yum install libboost-test-dev
+yum install libeigen3-dev
+yum install libsuitesparse-dev
+# yum install libfreeimage-dev
+yum install libgoogle-glog-dev
+yum install libgflags-dev
+yum install libglew-dev
+yum install qtbase5-dev
+yum install libqt5opengl5-dev
+yum install libcgal-dev
+yum install libcgal-qt5-dev
+
+yum -y install freeimage
+
+### ------ Build FreeImage from source and install --------------------
+cd $CURRDIR
+wget http://downloads.sourceforge.net/freeimage/FreeImage3180.zip
+unzip FreeImage3180.zip
+cd FreeImage
+make
+make install
+
+# Install GLEW
+yum -y install glew-devel
+
+# ---------------- Clone COLMAP ----------------------------------------------------------
+cd $CURRDIR
+git clone https://github.com/colmap/colmap.git
+cd colmap
+git checkout dev
+
+# ----------- Build COLMAP ------------------------------------------------------------
+mkdir build/
+cd build/
+cmake .. -DCMAKE_BUILD_TYPE=Release \
+         -DBoost_USE_STATIC_LIBS=ON \
+         -DBOOST_ROOT=/usr/local \
+         -DEIGEN3_INCLUDE_DIRS=/eigen-3.3.9
+
+if [ $ec -ne 0 ]; then
+    echo "Error:"
+    cat ./CMakeCache.txt
+    exit $ec
+fi
+set -e -x
+
+make -j$(nproc) install
+
+mkdir -p /io/wheelhouse
+
+# ----------- Build pycolmap wheel -----------------------------------------------------
+cd /io/
+#cp package/setup_centos.py setup.py
+cat setup.py
+
+PLAT=manylinux2014_x86_64
+#"${PYBIN}/python" setup.py bdist_wheel --python-tag=$PYTHONVER --plat-name=$PLAT
+EIGEN3_INCLUDE_DIRS="/eigen-3.3.9" "${PYBIN}/python" setup.py bdist_wheel --plat-name=$PLAT #--python-tag=$PYTHONVER
+
+# Bundle external shared libraries into the wheels
+for whl in ./dist/*.whl; do
+    auditwheel repair "$whl" -w /io/wheelhouse/ --no-update-tags
+done
+
+ls -ltrh /io/wheelhouse/
+# for whl in /io/wheelhouse/*.whl; do
+#     new_filename=$(echo $whl | sed "s#\.none-manylinux2014_x86_64\.#.#g")
+#     new_filename=$(echo $new_filename | sed "s#\.manylinux2014_x86_64\.#.#g") # For 37 and 38
+#     new_filename=$(echo $new_filename | sed "s#-none-#-#g")
+#     mv $whl $new_filename
+# done

--- a/package/build-wheels-macos.sh
+++ b/package/build-wheels-macos.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+set -x -e
+
+function retry {
+  local retries=$1
+  shift
+
+  local count=0
+  until "$@"; do
+    exit=$?
+    wait=$((2 ** $count))
+    count=$(($count + 1))
+    if [ $count -lt $retries ]; then
+      echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+      sleep $wait
+    else
+      echo "Retry $count/$retries exited $exit, no more retries left."
+      return $exit
+    fi
+  done
+  return 0
+}
+
+brew update
+brew upgrade
+brew install wget python cmake || true
+# TODO: try without brew install of boost, but use version below
+brew install git cmake boost eigen freeimage glog gflags suite-sparse ceres-solver glew cgal qt5
+
+brew install llvm libomp
+
+brew info gcc
+brew upgrade gcc
+brew info gcc
+
+echo 'export PATH="/usr/local/opt/qt@5/bin:$PATH"' >> /Users/runner/.bash_profile
+
+CURRDIR=$(pwd)
+ls -ltrh $CURRDIR
+
+
+
+# Build Boost staticly
+mkdir -p boost_build
+cd boost_build
+retry 3 wget https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.gz
+tar xzf boost_1_73_0.tar.gz
+cd boost_1_73_0
+./bootstrap.sh --prefix=$CURRDIR/boost_install --with-libraries=serialization,filesystem,thread,system,atomic,date_time,timer,chrono,program_options,regex clang-darwin
+./b2 -j$(sysctl -n hw.logicalcpu) cxxflags="-fPIC" runtime-link=static variant=release link=static install
+
+echo "CURRDIR is: ${CURRDIR}"
+
+cd $CURRDIR
+mkdir -p $CURRDIR/wheelhouse_unrepaired
+mkdir -p $CURRDIR/wheelhouse
+
+ORIGPATH=$PATH
+
+PYTHON_LIBRARY=$(cd $(dirname $0); pwd)/libpython-not-needed-symbols-exported-by-interpreter
+touch ${PYTHON_LIBRARY}
+
+declare -a PYTHON_VERS=( $1 )
+
+# Get the python version numbers only by splitting the string
+split_array=(${PYTHON_VERS//@/ })
+VERSION_NUMBER=${split_array[1]}
+
+git clone https://github.com/colmap/colmap.git
+
+sed -i -e 's/Qt5 5.4/Qt5 5.15.2/g' colmap/CMakeLists.txt
+
+for compiler in cc c++ gcc g++ clang clang++
+do
+    which $compiler
+    $compiler --version
+done
+
+echo "Python versions: ${PYTHON_VERS[@]}"
+# Compile wheels
+for PYVER in ${PYTHON_VERS[@]}; do
+    PYBIN="/usr/local/opt/$PYVER/bin"
+
+    PYTHONVER="$(basename $(dirname $PYBIN))"
+    BUILDDIR="$CURRDIR/colmap_$PYTHONVER/colmap_build"
+    mkdir -p $BUILDDIR
+    cd $BUILDDIR
+    export PATH=$PYBIN:$PYBIN:/usr/local/bin:$ORIGPATH
+    PYTHON_EXECUTABLE=${PYBIN}/python3
+
+
+    # Install `delocate` -- OSX equivalent of `auditwheel` -- see https://pypi.org/project/delocate/ for more details
+    cd $CURRDIR
+    #git clone https://github.com/matthew-brett/delocate.git
+    #cd delocate
+    #"${PYBIN}/pip3" install -e . # delocate==0.8.2
+    "${PYBIN}/pip3" install delocate==0.10.0
+
+    ls -ltrh /usr/local
+    ls -ltrh /usr/local/opt
+
+    cd $CURRDIR
+    cd colmap
+    git checkout dev
+    mkdir build_$PYTHONVER
+    cd build_$PYTHONVER
+    cmake .. -DQt5_DIR=/usr/local/opt/qt@5/lib/cmake/Qt5
+
+    # examine exit code of last command
+    ec=$?
+
+    if [ $ec -ne 0 ]; then
+        echo "Error:"
+        cat ./CMakeCache.txt
+        exit $ec
+    fi
+    set -e -x
+
+    NUM_LOGICAL_CPUS=$(sysctl -n hw.logicalcpu)
+    echo "Number of logical CPUs is: ${NUM_LOGICAL_CPUS}"
+    make -j $NUM_LOGICAL_CPUS install
+    sudo make install
+
+    cd $CURRDIR
+    cat setup.py
+
+    # flags must be passed, to avoid the issue: `Unsupported compiler -- pybind11 requires C++11 support!`
+    # see https://github.com/quantumlib/qsim/issues/242 for more details
+    Qt5_DIR="/usr/local/opt/qt@5/lib/cmake/Qt5" CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ LDFLAGS=-L/usr/local/opt/libomp/lib "${PYBIN}/python3" setup.py bdist_wheel
+    cp ./dist/*.whl $CURRDIR/wheelhouse_unrepaired
+done
+
+ls -ltrh $CURRDIR/wheelhouse_unrepaired/
+# Bundle external shared libraries into the wheels
+for whl in $CURRDIR/wheelhouse_unrepaired/*.whl; do
+    delocate-listdeps --all "$whl"
+    delocate-wheel -w "$CURRDIR/wheelhouse" -v "$whl"
+    rm $whl
+done

--- a/package/build-wheels-macos.sh
+++ b/package/build-wheels-macos.sh
@@ -34,11 +34,10 @@ brew upgrade gcc
 brew info gcc
 
 echo 'export PATH="/usr/local/opt/qt@5/bin:$PATH"' >> /Users/runner/.bash_profile
+export Qt5_CMAKE_DIR="/usr/local/opt/qt@5/lib/cmake/Qt5"
 
 CURRDIR=$(pwd)
 ls -ltrh $CURRDIR
-
-
 
 # Build Boost staticly
 mkdir -p boost_build
@@ -89,11 +88,9 @@ for PYVER in ${PYTHON_VERS[@]}; do
     PYTHON_EXECUTABLE=${PYBIN}/python3
 
 
-    # Install `delocate` -- OSX equivalent of `auditwheel` -- see https://pypi.org/project/delocate/ for more details
+    # Install `delocate` -- OSX equivalent of `auditwheel`
+    # see https://pypi.org/project/delocate/ for more details
     cd $CURRDIR
-    #git clone https://github.com/matthew-brett/delocate.git
-    #cd delocate
-    #"${PYBIN}/pip3" install -e . # delocate==0.8.2
     "${PYBIN}/pip3" install delocate==0.10.0
 
     ls -ltrh /usr/local
@@ -104,7 +101,7 @@ for PYVER in ${PYTHON_VERS[@]}; do
     git checkout dev
     mkdir build_$PYTHONVER
     cd build_$PYTHONVER
-    cmake .. -DQt5_DIR=/usr/local/opt/qt@5/lib/cmake/Qt5
+    cmake .. -DQt5_DIR=$Qt5_CMAKE_DIR
 
     # examine exit code of last command
     ec=$?
@@ -126,12 +123,12 @@ for PYVER in ${PYTHON_VERS[@]}; do
 
     # flags must be passed, to avoid the issue: `Unsupported compiler -- pybind11 requires C++11 support!`
     # see https://github.com/quantumlib/qsim/issues/242 for more details
-    Qt5_DIR="/usr/local/opt/qt@5/lib/cmake/Qt5" CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ LDFLAGS=-L/usr/local/opt/libomp/lib "${PYBIN}/python3" setup.py bdist_wheel
+    Qt5_DIR="Qt5_CMAKE_DIR" CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ LDFLAGS=-L/usr/local/opt/libomp/lib "${PYBIN}/python3" setup.py bdist_wheel
     cp ./dist/*.whl $CURRDIR/wheelhouse_unrepaired
 done
 
-ls -ltrh $CURRDIR/wheelhouse_unrepaired/
 # Bundle external shared libraries into the wheels
+ls -ltrh $CURRDIR/wheelhouse_unrepaired/
 for whl in $CURRDIR/wheelhouse_unrepaired/*.whl; do
     delocate-listdeps --all "$whl"
     delocate-wheel -w "$CURRDIR/wheelhouse" -v "$whl"

--- a/package/build-wheels-macos.sh
+++ b/package/build-wheels-macos.sh
@@ -25,16 +25,13 @@ brew update
 brew upgrade
 brew install wget python cmake || true
 # TODO: try without brew install of boost, but use version below
-brew install git cmake boost eigen freeimage glog gflags suite-sparse ceres-solver glew cgal qt5
+brew install git cmake boost eigen freeimage glog gflags suite-sparse ceres-solver glew cgal
 
 brew install llvm libomp
 
 brew info gcc
 brew upgrade gcc
 brew info gcc
-
-echo 'export PATH="/usr/local/opt/qt@5/bin:$PATH"' >> /Users/runner/.bash_profile
-export Qt5_CMAKE_DIR="/usr/local/opt/qt@5/lib/cmake/Qt5"
 
 CURRDIR=$(pwd)
 ls -ltrh $CURRDIR
@@ -60,8 +57,6 @@ touch ${PYTHON_LIBRARY}
 declare -a PYTHON_VERS=( $1 )
 
 git clone https://github.com/colmap/colmap.git
-
-sed -i -e 's/Qt5 5.4/Qt5 5.15.2/g' colmap/CMakeLists.txt
 
 for compiler in cc c++ gcc g++ clang clang++
 do
@@ -89,7 +84,7 @@ cd colmap
 git checkout dev
 mkdir build
 cd build
-cmake .. -DQt5_DIR=$Qt5_CMAKE_DIR
+cmake .. -DGUI_ENABLED=OFF
 
 # examine exit code of last command
 ec=$?
@@ -109,7 +104,7 @@ cd $CURRDIR
 cat setup.py
 # flags must be passed, to avoid the issue: `Unsupported compiler -- pybind11 requires C++11 support!`
 # see https://github.com/quantumlib/qsim/issues/242 for more details
-Qt5_DIR="$Qt5_CMAKE_DIR" CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ LDFLAGS=-L/usr/local/opt/libomp/lib "${PYBIN}/python3" setup.py bdist_wheel
+CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ LDFLAGS=-L/usr/local/opt/libomp/lib "${PYBIN}/python3" setup.py bdist_wheel
 cp ./dist/*.whl $CURRDIR/wheelhouse_unrepaired
 
 # Bundle external shared libraries into the wheels

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,17 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+        cmake_args = [
+            '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+            '-DPYTHON_EXECUTABLE=' + sys.executable,
+            '-DVERSION_INFO={}'.format(self.distribution.get_version()),
+        ]
+        eigen_dir = os.environ.get('EIGEN3_INCLUDE_DIRS')
+        if eigen_dir is not None:
+            cmake_args += ['-DEIGEN3_INCLUDE_DIRS={}'.format(eigen_dir)]
+        qt5_dir = os.environ.get("Qt5_DIR")
+        if qt5_dir is not None:
+            cmake_args += ['-DQt5_DIR={}'.format(qt5_dir)]
 
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]

--- a/two_view_geometry_estimation.cc
+++ b/two_view_geometry_estimation.cc
@@ -1,0 +1,111 @@
+
+#include <iostream>
+#include <fstream>
+
+#include "colmap/base/camera.h"
+#include "colmap/base/pose.h"
+#include "colmap/estimators/two_view_geometry.h"
+#include "colmap/optim/loransac.h"
+#include "colmap/util/random.h"
+
+using namespace colmap;
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/eigen.h>
+
+namespace py = pybind11;
+
+/*
+* Estimate two-view geometry relationship for a calibrated camera.
+* 
+* param points2D1,
+* param points2D2,
+* param camera_dict1
+* param camera_dict2
+* param max_error_px,
+* param min_inlier_ratio,
+* param min_num_trials,
+* param max_num_trials,
+* param confidence
+* @return The most probable rotation matrix (3x3), translation vector (3x1), and two view
+*         configuration type (UNDEFINED, DEGENERATE, CALIBRATED, UNCALIBRATED, PLANAR
+*         PANORAMIC, PLANAR_OR_PANORAMIC, WATERMARK, or MULTIPLE).
+*         See https://github.com/colmap/colmap/blob/dev/src/estimators/two_view_geometry.h#L48
+*/
+py::dict two_view_geometry_estimation(
+        const std::vector<Eigen::Vector2d> points2D1,
+        const std::vector<Eigen::Vector2d> points2D2,
+        const py::dict camera_dict1,
+        const py::dict camera_dict2,
+        const double max_error_px,
+        const double min_inlier_ratio,
+        const int min_num_trials,
+        const int max_num_trials,
+        const double confidence
+) {
+    SetPRNGSeed(0);
+
+    // Check that both vectors have the same size.
+    assert(points2D1.size() == points2D2.size());
+
+    // Failure output dictionary.
+    py::dict failure_dict;
+    failure_dict["success"] = false;
+
+    // Create cameras.
+    Camera camera1;
+    camera1.SetModelIdFromName(camera_dict1["model"].cast<std::string>());
+    camera1.SetWidth(camera_dict1["width"].cast<size_t>());
+    camera1.SetHeight(camera_dict1["height"].cast<size_t>());
+    camera1.SetParams(camera_dict1["params"].cast<std::vector<double>>());
+
+    Camera camera2;
+    camera2.SetModelIdFromName(camera_dict2["model"].cast<std::string>());
+    camera2.SetWidth(camera_dict2["width"].cast<size_t>());
+    camera2.SetHeight(camera_dict2["height"].cast<size_t>());
+    camera2.SetParams(camera_dict2["params"].cast<std::vector<double>>());
+
+    FeatureMatches matches;
+    matches.reserve(points2D1.size());
+    
+    for (size_t i=0; i < points2D1.size(); i++) {
+       matches.emplace_back(i,i);
+    }
+ 
+    TwoViewGeometry two_view_geometry;
+    TwoViewGeometry::Options two_view_geometry_options;
+    two_view_geometry_options.ransac_options.max_error = max_error_px;
+    two_view_geometry_options.ransac_options.min_inlier_ratio = min_inlier_ratio;
+    two_view_geometry_options.ransac_options.min_num_trials = min_num_trials;
+    two_view_geometry_options.ransac_options.max_num_trials = max_num_trials;
+    two_view_geometry_options.ransac_options.confidence = confidence;
+    
+    two_view_geometry.EstimateCalibrated(camera1, points2D1, camera2, points2D2, matches, two_view_geometry_options);
+
+    // Success output dictionary.
+    py::dict success_dict;
+
+    if (!two_view_geometry.EstimateRelativePose(camera1, points2D1, camera2, points2D2)) {
+        return failure_dict;
+    } else {
+        success_dict["success"] = true;
+    }
+  
+    const FeatureMatches inlier_matches = two_view_geometry.inlier_matches;
+    
+    // Convert vector<char> to vector<int>.
+    std::vector<bool> inliers(points2D1.size(), false);
+    for (auto m : inlier_matches) {
+        inliers[m.point2D_idx1] = true;
+    }
+  
+    // Recover data.
+    success_dict["configuration_type"] = two_view_geometry.config;
+    success_dict["qvec"] = two_view_geometry.qvec;
+    success_dict["tvec"] = two_view_geometry.tvec;
+    success_dict["num_inliers"] = inlier_matches.size();
+    success_dict["inliers"] = inliers;
+    
+    return success_dict;
+}


### PR DESCRIPTION
At each PR or push to master, wheels for Linux and macOS are built with GitHub Actions and available [here](https://github.com/mihaidusmanu/pycolmap/actions). Optionally, we automatically publish them to pypi. Build time is currently ~25min.

Based on @johnwlambert excellent repo https://github.com/johnwlambert/pycolmap-wheels with some differences:
- fix some issues with wheel filenames
- pass Eigen3 (for CentOS) and Qt5 (for macOS) flags to `setup.py`
- add package version as module attribute
- use C++14 when Ceres>=2.0
- automatically publish to pypi if a new tag is pushed (e.g. by a new release)

TODO:
- [x] cleanup the *.sh scripts
- [x] make macOS work reliably

Any help is very much appreciated.

## Note on macOS

I am on 11.4 but `python3 -c "from distutils import util; print(util.get_platform())"` returns `macosx-10.15-x86_64`. Building with the target `macos-11` produces `pycolmap-0.0.2-cp39-cp39-macosx_11_0_x86_64.whl`. This is rejected by pip unless I rename it to `pycolmap-0.0.2-cp39-none-macosx_10_9_x86_64.whl`. Then the macOS wheel work perfectly. I have no idea why this happens and why the abi tag needs to be `none`.

cc @mihaidusmanu @Phil26AT @johnwlambert 